### PR TITLE
Fix a few typos and delete a duplicated section

### DIFF
--- a/bioconductor/index.qmd
+++ b/bioconductor/index.qmd
@@ -50,7 +50,7 @@ In addition to easing the build process, avoiding unnecessary R version restrict
 
 ## Debugging the CI
 
-If you develop your package on GitHub, it is possible to the exact same workflow from your own GitHub repository. This allows you to test or debug the build and check process on your R package, exactly as it will happen on R-universe, but without actually deploying to https://r-universe.dev.
+If you develop your package on GitHub, it is possible to run the exact same workflow from your own GitHub repository. This allows you to test or debug the build and check process on your R package, exactly as it will happen on R-universe, but without actually deploying to https://r-universe.dev.
 
 
 ```yaml

--- a/bioconductor/index.qmd
+++ b/bioconductor/index.qmd
@@ -41,7 +41,7 @@ It is also possible to link directly to this check table, e.g. https://bioc.r-un
 
 ## On R version compatibility
 
-Bioconductor traditionally assumes a specific version of R for each version of the package. However we still recommend __not__ put unnecessary version constraints like `R > 4.6` in your package DESCRIPTION file, and instead try to make the package work at least with the `release` and `devel` version of R.
+Bioconductor traditionally assumes a specific version of R for each version of the package. However we still recommend __not__ to put unnecessary version constraints like `R > 4.6` in your package DESCRIPTION file, and instead try to make the package work at least with the `release` and `devel` version of R.
 
 Doing so will smoothen the transition because many pieces of the build infrastructure use the current R `release` version to render components or calculate metrics to get thing published. If your package uses newly introduced R API's from R-devel, we recommend adding a [backport as explained in WRE](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Some-backports) to make it also work with r-release. Feel free to reach out if you could use some help with this!
 

--- a/bioconductor/index.qmd
+++ b/bioconductor/index.qmd
@@ -43,7 +43,7 @@ It is also possible to link directly to this check table, e.g. https://bioc.r-un
 
 Bioconductor traditionally assumes a specific version of R for each version of the package. However we still recommend __not__ to put unnecessary version constraints like `R > 4.6` in your package DESCRIPTION file, and instead try to make the package work at least with the `release` and `devel` version of R.
 
-Doing so will smoothen the transition because many pieces of the build infrastructure use the current R `release` version to render components or calculate metrics to get thing published. If your package uses newly introduced R API's from R-devel, we recommend adding a [backport as explained in WRE](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Some-backports) to make it also work with r-release. Feel free to reach out if you could use some help with this!
+Doing so will smoothen the transition because many pieces of the build infrastructure use the current R `release` version to render components or calculate metrics to get things published. If your package uses newly introduced R API's from R-devel, we recommend adding a [backport as explained in WRE](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Some-backports) to make it also work with r-release. Feel free to reach out if you could use some help with this!
 
 In addition to easing the build process, avoiding unnecessary R version restrictions can make your work more useful to the greater R community, as packages from other repositories could depend on your package, but without limiting their users to a given version of R.
 

--- a/browse/api.qmd
+++ b/browse/api.qmd
@@ -135,7 +135,7 @@ Parameters:
 
 - q: Query string (supports [advanced fields](/browse/search.html)).
 - limit: Maximum number of results (default: 100). To retrieve all results:
-    - Perform an initial query to get the value `total` field.
+    - Perform an initial query to get the value of the `total` field.
     - Perform a second query with `limit=total`.
 
 Using `{httr2}`:

--- a/browse/packages.qmd
+++ b/browse/packages.qmd
@@ -98,7 +98,7 @@ The root domain `https://cran.dev/{package}` redirects to the primary homepage f
   - https://cran.dev/Matrix
   - https://cran.dev/ggplot2
 
-The subdomain `https://docs.cran.dev/{package}` redirects to package manual page:
+The subdomain `https://docs.cran.dev/{package}` redirects to the package manual page:
 
   - https://docs.cran.dev/targets
   - https://docs.cran.dev/MASS

--- a/browse/packages.qmd
+++ b/browse/packages.qmd
@@ -88,7 +88,7 @@ These link to the respective chapters in the html reference manual, which provid
 ### cran.dev shortlinks
 
 On R-universe you can find package repositories from many different organizations and maintainers.
-But sometimes you just want to lookup a particular CRAN package, without knowing the developer.
+But sometimes you just want to look up a particular CRAN package, without knowing the developer.
 The cran.dev shortlink service lets you navigate or link directly to the R-universe homepage and docs of any established CRAN package.
 
 

--- a/browse/packages.qmd
+++ b/browse/packages.qmd
@@ -160,7 +160,7 @@ The information on development is only accurate if the developers push to the tr
 
 Besides familiarizing yourself with what the package does, you may be interested in who is working on it, who else is using it, and if it is still actively developed.
 
-![Development information the sf package](../img/pkg-development.png){group="pkg" fig-alt="Development information the sf package"}
+![Development information for the sf package](../img/pkg-development.png){group="pkg" fig-alt="Development information for the sf package"}
 
 The “development and contributors” section shows a bar chart with the number of commits per week for the last year, and who the main contributors are. 
 Finally the section “usage by other packages” shows other packages on R-universe depending on this package, grouped by owner. 

--- a/browse/search.qmd
+++ b/browse/search.qmd
@@ -57,13 +57,6 @@ We plan to keep updating the algorithm as R-universe matures and better data bec
 
 As a package maintainer, you can [optimize your package's metadata](#keywords) and work on [improving its rank](#better-rank).
 
-## Why is a package sometimes listed twice?
-
-If a source package fails to build (which means something is very wrong) then you see a red “build failure” message.
-If there was a previous successful build, it is kept there as well for users to install.
-You can explore [scores and metrics for all packages](https://r-universe.dev/packages).  
-The algorithm will evolve as R-universe matures and better data becomes available.
-
 ## Which packages get included in search? {#deduplication}
 
 In R-universe, a given R package can appear in multiple registries.

--- a/browse/search.qmd
+++ b/browse/search.qmd
@@ -45,7 +45,7 @@ The exact algorithm for calculating popularity/quality is a work-in-progress and
 At the time of writing it includes:
 
  - Number of dependents (that is to say, recursive reverse dependencies);
- - Number of stars on Github;
+ - Number of stars on GitHub;
  - Number of unique contributors;
  - Commit activity over the last year;
  - Downloads per month from CRAN or Bioconductor mirrors;

--- a/index.qmd
+++ b/index.qmd
@@ -25,7 +25,7 @@ Are you...
 
 - An R user that just wants to search something or retrieve information;
 - A package developer;
-- A universe developer (aka r-multiverse /pharmaverse /biocondctor or similar people); 
+- A universe developer (aka r-multiverse /pharmaverse /bioconductor or similar people); 
 - Someone willing to contribute to r-universe to improve the infrastructure or documentation?
 
 This documentation should help. 

--- a/infra/governance.qmd
+++ b/infra/governance.qmd
@@ -10,7 +10,7 @@ rOpenSci is a non-profit initiative that supports open and reproducible science 
 rOpenSci builds a welcoming and diverse community. 
 rOpenSci curates a blog, coworking events, community calls.
 
-R-universe development is lead by [Jeroen Ooms](https://github.com/jeroen/).
+R-universe development is led by [Jeroen Ooms](https://github.com/jeroen/).
 
 ## Funding {#funding}
 

--- a/install/binaries.qmd
+++ b/install/binaries.qmd
@@ -33,7 +33,7 @@ Also see how this is done automatically in the [base image Rprofile](https://git
 
 ## Binaries for packages with compiled code
 
-In information on packages provided by the [API](#api-pkg), the `arch` field to the `binaries` field only if there is compiled code in the package. 
+In information on packages provided by the [API](#api-pkg), the `arch` field is added to the `binaries` field only if there is compiled code in the package. 
 Packages without compiled code are identical on all architectures.
 
 On MacOS and Linux we only build a separate x86_64 and arm64 version for packages with compiled code, otherwise the same binary is used for both.

--- a/install/binaries.qmd
+++ b/install/binaries.qmd
@@ -12,7 +12,7 @@ On Linux, R-universe builds and checks Linux binaries for R-devel and R-release,
 https://${owner}.r-universe.dev/bin/linux/${distro}-${arch}/${rversion}/
 ```
 
-There is no need to set a custom user agent. To install these binaries on Linux, add the corresponding repository to your `repos`. You can use the `cran.r-universe.dev` instead of a regular CRAN mirror in order to get binaries for all the CRAN dependencies as well. Below is an example function that you can put in e.g. your `~/.Rprofile` file to set the `option(repos)` :
+There is no need to set a custom user agent. To install these binaries on Linux, add the corresponding repository to your `repos`. You can use the `cran.r-universe.dev` instead of a regular CRAN mirror in order to get binaries for all the CRAN dependencies as well. Below is an example function that you can put in e.g. your `~/.Rprofile` file to set the `options(repos)` :
 
 ```r
 linux_binary_repo <- function(universe){

--- a/install/dependencies.qmd
+++ b/install/dependencies.qmd
@@ -65,6 +65,6 @@ or a solution that will automatically prompt the user to install the missing pac
 rlang::check_installed("targets", action = function(...) install.packages('targets', repos = c('https://ropensci.r-universe.dev', 'https://cloud.r-project.org')))
 ```
 
-## How to use a universe on regular continous integration?
+## How to use a universe on regular continuous integration?
 
 If you want to test a package against versions of other packages that are in a universe, on GitHub Actions you can use the [`extra-repositories` field of the `r-lib/actions` setup-r action](https://github.com/r-lib/actions/tree/v2-branch/setup-r#inputs).

--- a/install/dependencies.qmd
+++ b/install/dependencies.qmd
@@ -12,7 +12,7 @@ For example, the following functions work:
 available.packages(repos = "https://tidyverse.r-universe.dev")
 
 # Installs dplyr and its dependencies from the tidyverse universe,
-# and its dependencies does not exist in the tidyverse universe are installed from CRAN
+# and dependencies that do not exist in the tidyverse universe are installed from CRAN
 install.packages("dplyr", repos = c("https://tidyverse.r-universe.dev", "https://cloud.r-project.org"))
 ```
 

--- a/publish/set-up.qmd
+++ b/publish/set-up.qmd
@@ -232,7 +232,7 @@ Alternatively, or as a complement, you can add an R-universe badge to indicate t
 ```
 
 The current implementation includes status for building vignettes and check results for R-release and R-devel on Windows, macOS and Linux.
-It shows the "worst result" of those checks, similar to what GitHub Action check badges do: if there is 1 "error", 1 "warning and 5 ok, the badge shows "error".
+It shows the "worst result" of those checks, similar to what GitHub Action check badges do: if there is 1 "error", 1 "warning" and 5 ok, the badge shows "error".
 
 The check status ignores R-oldrel and platforms where we only build binaries but do not check (webassembly), to avoid false positives.
 

--- a/publish/set-up.qmd
+++ b/publish/set-up.qmd
@@ -126,7 +126,7 @@ To publish your registry, create a Git repository called `<yourname>.r-universe.
 
 ### Custom metadata
 
-It is possible to add custom metadata by using the `metadata` field in each package entries `packages.json` for example see the [rOpenSci package registry](https://github.com/ropensci/roregistry/blob/gh-pages/packages.json):
+It is possible to add custom metadata by using the `metadata` field in each package entry of `packages.json` for example see the [rOpenSci package registry](https://github.com/ropensci/roregistry/blob/gh-pages/packages.json):
 
 ```json
   {

--- a/publish/set-up.qmd
+++ b/publish/set-up.qmd
@@ -153,7 +153,7 @@ ijtiff[["_metadata"]]
 ```
 
 For some cases we can also expose some metadata in the WebUI. 
-If the metadata contains `review` data then is [shown](https://github.com/r-universe-org/frontend/blob/3ecaaa787d37776d84bd5f3cad5110d4adb2c793/views/pkginfo.pug#L127-L135) on [package pages](/browse/packages.html): example of [ijtiff package page](https://ropensci.r-universe.dev/ijtiff).
+If the metadata contains `review` data then it is [shown](https://github.com/r-universe-org/frontend/blob/3ecaaa787d37776d84bd5f3cad5110d4adb2c793/views/pkginfo.pug#L127-L135) on [package pages](/browse/packages.html): example of [ijtiff package page](https://ropensci.r-universe.dev/ijtiff).
 
 If useful we could conditionally display other sorts of meta information, [get in touch](https://github.com/r-universe-org/help/discussions).
 

--- a/publish/troubleshoot-build.qmd
+++ b/publish/troubleshoot-build.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Trouble shoot package builds"
+title: "Troubleshoot package builds"
 ---
 
 ## How often is data updated? {#data-updates}

--- a/publish/troubleshoot-build.qmd
+++ b/publish/troubleshoot-build.qmd
@@ -31,7 +31,7 @@ Currently the only option is `cran_version` which has to be a `yyyy-mm-dd` strin
 
 This will set `options(repos = c(CRAN = "https://p3m.dev/cran/2025-01-15"))`
 
-## What if the Git repository  is not a ready-to-build source package?
+## What if the Git repository is not a ready-to-build source package?
 
 For repositories requiring additional preparation before building, you can add a [script](https://github.com/r-universe-org/build-source/blob/5830b8aa92d5524b3af6d1b617e605d1a2558543/entrypoint.sh#L50-L57) at the root of the package:  
 

--- a/publish/troubleshoot-build.qmd
+++ b/publish/troubleshoot-build.qmd
@@ -65,7 +65,7 @@ It builds and deploys R packages from Git into personal CRAN-like repositories.
 
 The universe owner is responsible for setting policies and ensuring quality control.  
 
-## How to use a universe on regular continous integration?
+## How to use a universe on regular continuous integration?
 
 If you want to test a package against versions of other packages that are in a universe, on GitHub Actions you can use the [`extra-repositories` field of the `r-lib/actions` setup-r action](https://github.com/r-lib/actions/tree/v2-branch/setup-r#inputs).
 

--- a/publish/troubleshoot-build.qmd
+++ b/publish/troubleshoot-build.qmd
@@ -71,7 +71,7 @@ If you want to test a package against versions of other packages that are in a u
 
 ## How to test the R-universe build workflow from your own GitHub repository
 
-To trouble-shoot why your package cannot be built by R-universe, you can use the same GitHub Actions workflow.
+To troubleshoot why your package cannot be built by R-universe, you can use the same GitHub Actions workflow.
 This is only possible on GitHub.
 
 The instructions on [r-universe-org/workflows](https://github.com/r-universe-org/workflows) explain how it works: 


### PR DESCRIPTION
I did a skim read through and fixed a few more typos (a couple only a native English speaker could spot, e.g. lead [the metal] compared to led [as in leading]).

Also in browse/search.qmd I spotted that the "Why is a package sometimes listed twice?" section was accidentally duplicated (it's currently 2.2 and 2.4). Obvs I don't know which version you prefer - maybe I chose the wrong one?

<img width="380" height="282" alt="CleanShot 2026-04-20 at 14 06 37@2x" src="https://github.com/user-attachments/assets/dbfc3e4c-ad3e-4181-a047-cc679c0497f8" />
